### PR TITLE
VS2013 linker error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,8 @@ config.log
 /lib/addons/library.kodi.guilib/Makefile
 /lib/addons/library.kodi.guilib/project/VS2010Express/Release
 /lib/addons/library.kodi.guilib/project/VS2010Express/Debug
+/lib/addons/library.xbmc.gui/project/VS2010Express/Debug/
+/lib/addons/library.xbmc.gui/project/VS2010Express/Release/
 /lib/addons/library.xbmc.addon/Makefile
 /lib/addons/library.kodi.adsp/Makefile
 /lib/addons/library.xbmc.pvr/Makefile
@@ -158,6 +160,8 @@ config.log
 /lib/addons/library.xbmc.codec/project/VS2010Express/Debug
 /lib/addons/library.xbmc.pvr/project/VS2010Express/Release
 /lib/addons/library.xbmc.pvr/project/VS2010Express/Debug
+/lib/addons/library.xbmc.adsp/project/VS2010Express/Debug/
+/lib/addons/library.xbmc.adsp/project/VS2010Express/Release/
 
 # /lib/cpluff/
 /lib/cpluff/ABOUT-NLS
@@ -931,6 +935,11 @@ lib/cpluff/stamp-h1
 /lib/libXDAAP/libXDAAP_win32/Debug
 /lib/libXDAAP/libXDAAP_win32/Release
 
+# /lib/cmyth/
+/system/libcmyth.dll
+/lib/cmyth/Win32/Release/
+/lib/cmyth/Win32/Debug/
+
 # /portable_data
 /portable_data
 
@@ -944,6 +953,12 @@ lib/cpluff/stamp-h1
 /addons/library.kodi.guilib/libKODI_guilib.lib
 /addons/library.xbmc.pvr/libXBMC_pvr.dll
 /addons/library.xbmc.pvr/libXBMC_pvr.lib
+addons/library.xbmc.adsp/libXBMC_adsp.dll
+addons/library.xbmc.adsp/libXBMC_adsp.lib
+addons/library.xbmc.gui/libXBMC_gui.dll
+addons/library.xbmc.gui/libXBMC_gui.lib
 
 /pvr-addons
 /adsp-addons
+
+

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -99,7 +99,7 @@ const int CGUIDialogAudioDSPSettings::m_StreamTypeNameTable[] =
   14061   //!< "Auto"
 };
 
-CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings()
+CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings(void)
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS, "DialogAudioDSPSettings.xml")
 {
   m_ActiveStreamId                                = 0;
@@ -113,7 +113,7 @@ CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings()
   m_MenuPositions[SETTING_AUDIO_CAT_PROC_INFO]    = CONTROL_SETTINGS_START_CONTROL+1;
 }
 
-CGUIDialogAudioDSPSettings::~CGUIDialogAudioDSPSettings()
+CGUIDialogAudioDSPSettings::~CGUIDialogAudioDSPSettings(void)
 { }
 
 int CGUIDialogAudioDSPSettings::FindCategoryIndex(const std::string &catId)

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
@@ -27,7 +27,7 @@ namespace ActiveAE
   class CGUIDialogAudioDSPSettings : public CGUIDialogSettingsManualBase
   {
   public:
-    CGUIDialogAudioDSPSettings();
+    CGUIDialogAudioDSPSettings(void);
     virtual ~CGUIDialogAudioDSPSettings();
 
     // specializations of CGUIControl


### PR DESCRIPTION
I don't know why, but without CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings(void) Kodi won't compile and VS2013 prdocues this linker error:
> Error 3	error LNK1120: 1 unresolved external symbol	<Kodi-Src>\project\VS2010Express\XBMC\Debug\Kodi.exe	Kodi

> Error 2 error LNK2019: Unresolved external symbol ""public: __thiscall ActiveAE::CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings(void)" (??0CGUIDialogAudioDSPSettings@ActiveAE@@QAE@XZ)" in function ""public: void __thiscall CGUIWindowManager::CreateWindows(void)" (?CreateWindows@CGUIWindowManager@@QAEXXZ)".	<Kodi-Src>\project\VS2010Express\GUIWindowManager.obj	Kodi

I also updated ignore list to prevent commiting generated files during a Kodi build.
