### PR TITLE
[adsp] Fix wrong addon enabled status & adsp addon registration process

### DIFF
--- a/project/cmake/addons/bootstrap/repositories/binary-addons.txt
+++ b/project/cmake/addons/bootstrap/repositories/binary-addons.txt
@@ -1,1 +1,1 @@
-binary-addons https://github.com/xbmc/repo-binary-addons.git master
+binary-addons https://github.com/AlwinEsch/repo-binary-addons.git master

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -721,8 +721,7 @@ bool CActiveAEDSP::UpdateAddons(void)
   {
     dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(*itr);
 
-    bool newRegistration = false;
-    if (RegisterAudioDSPAddon(dspAddon, &newRegistration) < 0 || newRegistration)
+    if (RegisterAudioDSPAddon(dspAddon) < 0)
     {
       CAddonMgr::GetInstance().DisableAddon(dspAddon->ID());
       --usableAddons;
@@ -797,12 +796,9 @@ void CActiveAEDSP::ShowDialogNoAddonsEnabled(void)
   g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
 }
 
-int CActiveAEDSP::RegisterAudioDSPAddon(AddonPtr addon, bool* newRegistration/*=NULL*/)
+int CActiveAEDSP::RegisterAudioDSPAddon(AddonPtr addon)
 {
   int iAddonId(-1);
-
-  if (newRegistration)
-    *newRegistration = false;
 
   if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
     return -1;
@@ -826,8 +822,6 @@ int CActiveAEDSP::RegisterAudioDSPAddon(AddonPtr addon, bool* newRegistration/*=
       CLog::Log(LOGERROR, "ActiveAE DSP - %s - can't add dsp addon '%s' to the database", __FUNCTION__, addon->Name().c_str());
       return -1;
     }
-    else if (newRegistration)
-      *newRegistration = true;
   }
 
   AE_DSP_ADDON dspAddon;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -326,7 +326,7 @@ bool CActiveAEDSP::IsInUse(const std::string &strAddonId) const
   CSingleLock lock(m_critSection);
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
-    if (citr->second->Enabled() && citr->second->ID() == strAddonId)
+    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()) && citr->second->ID() == strAddonId)
       return true;
   return false;
 }
@@ -624,8 +624,7 @@ bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSP
   for (unsigned iAddonPtr = 0; iAddonPtr < map.size(); ++iAddonPtr)
   {
     const AddonPtr dspAddon = map.at(iAddonPtr);
-    bool bEnabled = dspAddon->Enabled() &&
-                    !CAddonMgr::GetInstance().IsAddonDisabled(dspAddon->ID());
+    bool bEnabled = !CAddonMgr::GetInstance().IsAddonDisabled(dspAddon->ID());
 
     if (!bEnabled && IsKnownAudioDSPAddon(dspAddon))
     {
@@ -665,7 +664,7 @@ bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSP
         }
 
         /* re-check the enabled status. newly installed dsps get disabled when they're added to the db */
-        if (!bDisabled && addon->Enabled() && (status = addon->Create(iAddonId)) != ADDON_STATUS_OK)
+        if (!bDisabled && !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && (status = addon->Create(iAddonId)) != ADDON_STATUS_OK)
         {
           CLog::Log(LOGWARNING, "ActiveAE DSP - %s - failed to create add-on %s, status = %d", __FUNCTION__, dspAddon->Name().c_str(), status);
           if (!addon.get() || !addon->DllLoaded() || status == ADDON_STATUS_PERMANENT_FAILURE)
@@ -805,7 +804,7 @@ int CActiveAEDSP::RegisterAudioDSPAddon(AddonPtr addon, bool* newRegistration/*=
   if (newRegistration)
     *newRegistration = false;
 
-  if (!addon->Enabled())
+  if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
     return -1;
 
   CLog::Log(LOGDEBUG, "ActiveAE DSP - %s - registering add-on '%s'", __FUNCTION__, addon->Name().c_str());
@@ -903,7 +902,7 @@ int CActiveAEDSP::EnabledAudioDSPAddonAmount(void) const
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (citr->second->Enabled())
+    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()))
       ++iReturn;
   }
 
@@ -922,7 +921,7 @@ int CActiveAEDSP::GetEnabledAudioDSPAddons(AE_DSP_ADDONMAP &addons) const
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (citr->second->Enabled())
+    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()))
     {
       addons.insert(std::make_pair(citr->second->GetID(), citr->second));
       ++iReturn;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
@@ -432,7 +432,7 @@ namespace ActiveAE
      * @param newRegistration pass in pointer to bool to return whether the client was newly registered.
      * @return The id of the addon if it was created or found in the existing addon map, -1 otherwise.
      */
-    int RegisterAudioDSPAddon(ADDON::AddonPtr addon, bool* newRegistration = NULL);
+    int RegisterAudioDSPAddon(ADDON::AddonPtr addon);
 
     /*!
      * @brief Get the instance of the dsp addon, if it's ready.

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
@@ -91,12 +91,12 @@ void CActiveAEDSPDatabase::CreateTables()
   // disable all Audio DSP add-on when started the first time
   ADDON::VECADDONS addons;
   if (CAddonMgr::GetInstance().GetAddons(ADDON_ADSPDLL, addons, true))
-    CLog::Log(LOGERROR, "Audio DSP - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
-  else
   {
     for (IVECADDONS it = addons.begin(); it != addons.end(); ++it)
       CAddonMgr::GetInstance().DisableAddon(it->get()->ID());
   }
+  else
+    CLog::Log(LOGERROR, "Audio DSP - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
 }
 
 void CActiveAEDSPDatabase::CreateAnalytics()


### PR DESCRIPTION
This PR solves a issue during adsp addon registration process. Furthermore it uses AddonManager for requesting the enabled status of addons.