### PR TITLE
[addon library] Fix undefined __stat64

### DIFF
--- a/addons/library.kodi.addon/addon.api2/definations.h
+++ b/addons/library.kodi.addon/addon.api2/definations.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <sys/stat.h>
+
 namespace AddOnLIB
 {
 namespace V2
@@ -92,6 +94,14 @@ namespace V2
 
   #define KODI_INVALID_CODEC_ID   0
   #define KODI_INVALID_CODEC      { KODI_CODEC_TYPE_UNKNOWN, KODI_INVALID_CODEC_ID }
+
+  #if !defined(__stat64)
+    #if defined(__APPLE__)
+      #define __stat64 stat
+    #else
+      #define __stat64 stat64
+    #endif
+  #endif
 
 }; /* namespace V2 */
 }; /* namespace AddOnLIB */

--- a/addons/library.kodi.addon/addon.api2/internal/libKODI_addon_Internal.h
+++ b/addons/library.kodi.addon/addon.api2/internal/libKODI_addon_Internal.h
@@ -49,9 +49,6 @@
 #else
   #include <dlfcn.h>              // linux+osx
 #endif
-#if defined(ANDROID)
-  #include <sys/stat.h>
-#endif
 
 #ifdef LOG_DEBUG
 #undef LOG_DEBUG


### PR DESCRIPTION
`CAddOnLib_File::StatFile()` doesn't #include a definition for __stat64.

In C++ the "struct" keyword before the parameter type isn't necessary. I recommend you remove it from the line:

```c++
static int StatFile(const std::string& strFileName, struct __stat64* buffer);
```

Unfortunately, its use here masks an error. This is because __stat64 is declared inline as a struct. As the declaration happens in the namespace `AddOnLIB::V2`, this is equivalent to

```c++
static int StatFile(const std::string& strFileName, struct AddOnLIB::V2::__stat64* buffer);
```

resulting in a compile error when you use the variable because `AddOnLIB::V2::__stat64` does not have a definition (which, btw: `s/definations/definitions/g`)